### PR TITLE
Feat: 외부 클릭 감지 커스텀 훅 추가

### DIFF
--- a/shared/hooks/useOnClickOutside.ts
+++ b/shared/hooks/useOnClickOutside.ts
@@ -12,26 +12,27 @@ import { useEffect } from 'react';
  * @param handler - 요소 바깥 클릭/터치 시 실행할 함수
  * @param enabled - (선택) true일 때만 동작, false면 비활성화 (기본값: true)
  */
-function useOnClickOutside<T extends HTMLElement>(
+export default function useOnClickOutside<T extends HTMLElement>(
   ref: React.RefObject<T | null>,
   handler: (event: MouseEvent | TouchEvent) => void,
   enabled = true,
 ) {
   useEffect(() => {
     if (!enabled) return;
+
     const listener = (event: MouseEvent | TouchEvent) => {
       if (!ref.current || ref.current.contains(event.target as Node)) {
         return;
       }
       handler(event);
     };
+
     document.addEventListener('mousedown', listener);
     document.addEventListener('touchstart', listener);
+
     return () => {
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler, enabled]);
+  }, [handler, enabled]);
 }
-
-export default useOnClickOutside;

--- a/shared/hooks/useOnClickOutside.ts
+++ b/shared/hooks/useOnClickOutside.ts
@@ -1,0 +1,37 @@
+// package
+import { useEffect } from 'react';
+
+/**
+ * 지정한 ref 요소 바깥을 클릭(또는 터치)하면 handler 함수가 실행되는 커스텀 훅
+ *
+ *  * 사용 예시:
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   useOnClickOutside(ref, () => setOpen(false));
+ *
+ * @param ref - 감지할 요소의 ref (useRef로 생성해서 전달)
+ * @param handler - 요소 바깥 클릭/터치 시 실행할 함수
+ * @param enabled - (선택) true일 때만 동작, false면 비활성화 (기본값: true)
+ */
+function useOnClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  handler: (event: MouseEvent | TouchEvent) => void,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler, enabled]);
+}
+
+export default useOnClickOutside;


### PR DESCRIPTION
### 작업한 내용
- `useOnClickOutside` 훅 추가
- `handler`, `enabled` 를 인자로 받아 외부 이벤트 감지
- `mousedown`, `touchstart` 이벤트를 사용하여 동작
- `enabled` 값을 통해 기능 활성/비활성 제어 가능
-----
### 참고사항
- 주로 드롭다운, 모달, 사이드바 등의 바깥 영역 클릭 시 닫기 기능에 사용
- SSR 환경에서는 `document` 객체가 없기 때문에 해당 훅은 클라이언트 사이드에서만 동작 가능
- `enabled` 값을 통해 조건부로 감지를 제어할 수 있어, 모달이 열렸을 때만 감지하도록 설정할 수 있음
- 이벤트 리스너는 컴포넌트 언마운트 시 정리되므로 메모리 누수 걱정 없이 사용 가능
