### PR TITLE
Feat: 태그 리스트 롤링(슬라이드) UI 구현

### DIFF
--- a/shared/hooks/useOnClickOutside.ts
+++ b/shared/hooks/useOnClickOutside.ts
@@ -12,26 +12,27 @@ import { useEffect } from 'react';
  * @param handler - 요소 바깥 클릭/터치 시 실행할 함수
  * @param enabled - (선택) true일 때만 동작, false면 비활성화 (기본값: true)
  */
-function useOnClickOutside<T extends HTMLElement>(
+export default function useOnClickOutside<T extends HTMLElement>(
   ref: React.RefObject<T | null>,
   handler: (event: MouseEvent | TouchEvent) => void,
   enabled = true,
 ) {
   useEffect(() => {
     if (!enabled) return;
+
     const listener = (event: MouseEvent | TouchEvent) => {
       if (!ref.current || ref.current.contains(event.target as Node)) {
         return;
       }
       handler(event);
     };
+
     document.addEventListener('mousedown', listener);
     document.addEventListener('touchstart', listener);
+
     return () => {
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler, enabled]);
+  }, [handler, enabled]);
 }
-
-export default useOnClickOutside;

--- a/shared/hooks/useOnClickOutside.ts
+++ b/shared/hooks/useOnClickOutside.ts
@@ -1,0 +1,37 @@
+// package
+import { useEffect } from 'react';
+
+/**
+ * 지정한 ref 요소 바깥을 클릭(또는 터치)하면 handler 함수가 실행되는 커스텀 훅
+ *
+ *  * 사용 예시:
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   useOnClickOutside(ref, () => setOpen(false));
+ *
+ * @param ref - 감지할 요소의 ref (useRef로 생성해서 전달)
+ * @param handler - 요소 바깥 클릭/터치 시 실행할 함수
+ * @param enabled - (선택) true일 때만 동작, false면 비활성화 (기본값: true)
+ */
+function useOnClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  handler: (event: MouseEvent | TouchEvent) => void,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler, enabled]);
+}
+
+export default useOnClickOutside;

--- a/views/tag/container/TagListCont.tsx
+++ b/views/tag/container/TagListCont.tsx
@@ -1,5 +1,5 @@
 // package
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // slice
 import TagListPres from '../presentational/TagListPres';

--- a/views/tag/container/TagListCont.tsx
+++ b/views/tag/container/TagListCont.tsx
@@ -1,0 +1,30 @@
+// package
+import React, { useEffect, useRef, useState } from 'react';
+
+// slice
+import TagListPres from '../presentational/TagListPres';
+
+type TagListContProps = {
+  tags: string[];
+};
+
+export default function TagListCont({ tags }: TagListContProps) {
+  const tagSlideRef = useRef<HTMLDivElement>(null);
+  const tagsRef = useRef<HTMLDivElement>(null);
+  const [shouldRoll, setShouldRoll] = useState(false);
+
+  // 태그 전체 너비가 보이는 영역보다 크면 롤링 활성화
+  useEffect(() => {
+    if (tagSlideRef.current && tagsRef.current) {
+      const containerWidth = tagSlideRef.current.offsetWidth;
+      const tagsWidth = tagsRef.current.scrollWidth;
+      setShouldRoll(tagsWidth > containerWidth);
+    }
+  }, []);
+
+  return (
+    <div ref={tagSlideRef} style={{ width: '100%' }}>
+      <TagListPres tags={tags} shouldRoll={shouldRoll} tagsRef={tagsRef} />
+    </div>
+  );
+}

--- a/views/tag/presentational/TagListPres.tsx
+++ b/views/tag/presentational/TagListPres.tsx
@@ -1,0 +1,38 @@
+// package
+import React from 'react';
+
+// slice
+import styles from '../styles/TagList.module.scss';
+
+type TagListPresProps = {
+  tags: string[];
+  shouldRoll: boolean;
+  tagsRef: React.RefObject<HTMLDivElement | null>;
+};
+export default function TagListPres({
+  tags,
+  shouldRoll,
+  tagsRef,
+}: TagListPresProps) {
+  return (
+    <div className={styles.tagListContainer}>
+      {/* 롤링이 필요할 경우 태그 리스트를 두 번 렌더링해 무한 롤링 효과 구현 */}
+      <div
+        className={`${styles.tagList} ${shouldRoll ? styles.rolling : ''}`}
+        ref={tagsRef}
+      >
+        {tags.map((tag, idx) => (
+          <span className={styles.tagItem} key={`${tag}-${idx}`}>
+            {tag}
+          </span>
+        ))}
+        {shouldRoll &&
+          tags.map((tag, idx) => (
+            <span className={styles.tagItem} key={`clone-${tag}-${idx}`}>
+              {tag}
+            </span>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/views/tag/presentational/TagListPres.tsx
+++ b/views/tag/presentational/TagListPres.tsx
@@ -1,6 +1,3 @@
-// package
-import React from 'react';
-
 // slice
 import styles from '../styles/TagList.module.scss';
 

--- a/views/tag/styles/TagList.module.scss
+++ b/views/tag/styles/TagList.module.scss
@@ -1,0 +1,39 @@
+@use '@styles/variables.scss' as *;
+
+.tagListContainer { 
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+  height: 32px;
+
+    &:hover .tagList.rolling {
+    animation-play-state: paused;
+  }
+}
+
+.tagList { 
+  display: flex;
+  gap: 8px;
+  width: max-content;
+}
+
+.rolling {
+  animation: slide 15s linear infinite; 
+}
+
+.tagItem {
+  background: $color-mist-lavender;
+  color: $color-primary;
+  border-radius: 16px;
+  font-size: 12px;
+  padding: 4px 16px;
+  font-weight: 400;
+}
+
+@keyframes slide {
+  from {
+    transform: translateX(0);
+  }to {
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
### 작업한 내용
- 태그 리스트가 컨테이너 너비를 초과할 경우 자동으로 롤링(슬라이드)되는 기능 추가
- 롤링 활성 시 태그 리스트를 두 번 렌더링하여 무한 롤링 효과 구현
-----
### 참고사항
- 태그 개수가 적어 컨테이너를 넘지 않으면 롤링 비활성화
- 태그 롤링 중 마우스 오버 시 애니메이션 일시정지
