### PR TITLE
Feat: 게시글 상세보기 페이지 컴포넌트 분리

### DIFF
--- a/app/(user)/[email]/stories/[id]/page.tsx
+++ b/app/(user)/[email]/stories/[id]/page.tsx
@@ -1,14 +1,19 @@
+'use client';
+
+import Button from '@/shared/ui/button';
 import styles from './styles.module.scss';
-import Image from 'next/image';
+import { LikeButton } from '@/features/like';
+import { BookmarkButton } from '@/features/bookmark';
+import Profile from '@/shared/ui/profile';
+import {
+  AiSummary,
+  BodyText,
+  CommentInput,
+  CommentList,
+} from '@/views/post-detail';
+import CommentLoginPromptPres from '@/views/post-detail/presentational/CommentLoginPromptPres';
 
 export default function Page() {
-  const comments = [
-    {
-      userNickName: 'userNickName',
-      date: '3일전',
-      text: '좋은글 잘읽고 갑니다~ 좋댓구알~',
-    },
-  ];
   return (
     <div className={styles.container}>
       {/* 제목 */}
@@ -17,109 +22,34 @@ export default function Page() {
       <div className={styles.profileLayout}>
         {/* 프로필/팔로우 바 */}
         <div className={styles.profileBar}>
-          <div className={styles.profileInfo}>
-            <Image
-              src="/svgs/profile.svg"
-              alt="user"
-              width={32}
-              height={32}
-              className={styles.profileIcon}
-            />
-            <div>
-              <div className={styles.profileName}>userNickName</div>
-              <div className={styles.profileDate}>2025-01-01</div>
-            </div>
-          </div>
-          <button className={styles.followBtn}>팔로우</button>
+          <Profile onClick={() => {}} />
+          <Button variants="active" size="small">
+            팔로우
+          </Button>
         </div>
 
         {/* 아이콘 바 */}
         <div className={styles.iconBar}>
-          <div className={styles.iconGroup}>
-            <Image
-              src="/svgs/book.svg"
-              alt="book"
-              width={21}
-              height={20}
-              className={styles.icon}
-            />
-          </div>
-          <div className={styles.iconGroup}>
-            <Image
-              src="/svgs/love.svg"
-              alt="love"
-              width={20}
-              height={20}
-              className={styles.icon}
-            />
-            <span className={styles.iconCount}>16</span>
-          </div>
+          <BookmarkButton />
+          <LikeButton />
         </div>
       </div>
 
       {/* AI 목차 요약 */}
-      <div className={styles.summaryBox}>
-        <div className={styles.summaryTitle}>AI 목차 요약</div>
-        <div className={styles.summaryItem}>CSR의 원리</div>
-        <div className={styles.summaryItem}>CSR의 적용기</div>
-        <div className={styles.summaryItem}>CSR의 문제점</div>
-      </div>
-
-      {/* 메인 이미지 */}
-      <Image
-        src="/svgs/image.svg"
-        alt="main"
-        width={600}
-        height={300}
-        className={styles.mainImage}
-      />
+      <AiSummary />
 
       {/* 본문 섹션 */}
-      <div className={styles.sectionTitle}>CSR 문제점</div>
-      <div className={styles.contentText}>
-        CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만,
-        좀더 인터렉티브한 디자인에는 좋은경험을 CSR은 클라이언트 사이드
-        렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한
-        디자인에는 좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고
-        합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는
-        좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는
-        SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........
-      </div>
+      <BodyText />
 
       {/* 댓글 타이틀 */}
       <div className={styles.commentTitle}>댓글 목록 (19)</div>
 
       {/* 댓글 등록 박스 */}
-      <div className={styles.commentBox}>
-        <input
-          className={styles.commentInput}
-          placeholder="댓글 등록하기"
-          disabled
-        />
-        <button className={styles.commentBtn}>로그인</button>
-      </div>
+      <CommentInput />
+      <CommentLoginPromptPres />
 
       {/* 댓글 리스트 */}
-      <div className={styles.commentList}>
-        {comments.map((c, idx) => (
-          <div className={styles.commentItem} key={idx}>
-            <Image
-              src="/svgs/profile.svg"
-              alt="user"
-              width={32}
-              height={32}
-              className={styles.commentProfile}
-            />
-            <div className={styles.commentContent}>
-              <div>
-                <span className={styles.commentUser}>{c.userNickName}</span>
-                <span className={styles.commentDate}> {c.date}</span>
-              </div>
-              <div className={styles.commentText}>{c.text}</div>
-            </div>
-          </div>
-        ))}
-      </div>
+      <CommentList />
     </div>
   );
 }

--- a/app/(user)/[email]/stories/[id]/page.tsx
+++ b/app/(user)/[email]/stories/[id]/page.tsx
@@ -14,6 +14,11 @@ import {
 import CommentLoginPromptPres from '@/views/post-detail/presentational/CommentLoginPromptPres';
 
 export default function Page() {
+  const dummy = {
+    userNickName: 'userNickName',
+    date: '2025-01-01',
+  };
+
   return (
     <div className={styles.container}>
       {/* 제목 */}
@@ -22,7 +27,11 @@ export default function Page() {
       <div className={styles.profileLayout}>
         {/* 프로필/팔로우 바 */}
         <div className={styles.profileBar}>
-          <Profile onClick={() => {}} />
+          <Profile
+            userNickName={dummy.userNickName}
+            date={dummy.date}
+            onClick={() => {}}
+          />
           <Button variants="active" size="small">
             팔로우
           </Button>

--- a/app/(user)/[email]/stories/[id]/page.tsx
+++ b/app/(user)/[email]/stories/[id]/page.tsx
@@ -10,8 +10,8 @@ import {
   BodyText,
   CommentInput,
   CommentList,
+  CommentLoginPrompt,
 } from '@/views/post-detail';
-import CommentLoginPromptPres from '@/views/post-detail/presentational/CommentLoginPromptPres';
 
 export default function Page() {
   const dummy = {
@@ -55,7 +55,7 @@ export default function Page() {
 
       {/* 댓글 등록 박스 */}
       <CommentInput />
-      <CommentLoginPromptPres />
+      <CommentLoginPrompt />
 
       {/* 댓글 리스트 */}
       <CommentList />

--- a/app/(user)/[email]/stories/[id]/styles.module.scss
+++ b/app/(user)/[email]/stories/[id]/styles.module.scss
@@ -1,209 +1,36 @@
-@use '@styles/variables.scss' as *;
+@use "@styles/variables.scss" as *;
 
 .container {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 0 16px;
+  padding: 32px 16px;
 }
 
 .title {
-  font-size: 36px;
-  font-weight: 700;
-  color: $color-text-1;
-  text-align: center;
-  margin-bottom: 8px;
+  font-size: $font-title-size;
+  color: $color-black;
+  text-align: left;
 }
 
 .profileLayout {
   width: 100%;
   display: flex;
+  justify-content: space-between;
 }
 
 .profileBar {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
   gap: 16px;
-}
-
-.profileInfo {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.profileIcon {
-  width: 32px;
-  height: 32px;
-}
-
-.profileName {
-  font-size: 12px;
-  color: $color-text-1;
-  font-weight: 400;
-}
-
-.profileDate {
-  font-size: 10px;
-  color: $color-text-3;
-  font-weight: 400;
-}
-
-.followBtn {
-  background: rgba(106, 90, 224, 0.8);
-  color: $color-white;
-  border-radius: 8px;
-  padding: 4px 12px;
-  font-size: 14px;
-  border: none;
-  cursor: pointer;
-  white-space: nowrap;
 }
 
 .iconBar {
   display: flex;
   align-items: center;
   gap: 16px;
-  width: 100%;
-}
-
-.iconGroup {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.icon {
-  width: 20px;
-  height: 20px;
-}
-
-.iconCount {
-  font-size: 12px;
-  color: $color-gray-800;
-  font-weight: 400;
-}
-
-.summaryBox {
-  width: 100%;
-  background: $color-mist-lavender;
-  border-radius: 8px;
-  padding: 16px;
-  margin: 16px 0;
-}
-
-.summaryTitle {
-  font-size: 24px;
-  font-weight: 600;
-  color: #B5A8FF;
-  text-align: center;
-  margin-bottom: 8px;
-}
-
-.summaryItem {
-  font-size: 12px;
-  color: $color-gray-800;
-  margin-bottom: 4px;
-}
-
-.mainImage {
-  width: 100%;
-  max-width: 600px;
-  border-radius: 8px;
-  margin: 24px 0 8px 0;
-}
-
-.sectionTitle {
-  font-size: 30px;
-  font-weight: 600;
-  color: $color-text-2;
-  margin: 24px 0 8px 0;
-}
-
-.contentText {
-  font-size: 20px;
-  color: $color-text-2;
-  line-height: 1.4;
-  margin-bottom: 24px;
 }
 
 .commentTitle {
-  font-size: 24px;
-  color: $color-text-1;
-  margin: 32px 0 16px 0;
-  text-align: center;
-}
-
-.commentBox {
-  background: #F6F7F8;
-  border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 16px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
-.commentInput {
-  width: 100%;
-  padding: 8px;
-  border-radius: 8px;
-  border: 1px solid $color-gray-400;
-  font-size: 16px;
-  margin-bottom: 8px;
-}
-
-.commentBtn {
-  background: rgba(106, 90, 224, 0.8);
-  color: $color-white;
-  border-radius: 8px;
-  padding: 4px 12px;
-  font-size: 16px;
-  border: none;
-  cursor: pointer;
-}
-
-.commentList {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 16px;
-}
-
-.commentItem {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  background: $color-white;
-  border-radius: 8px;
-  padding: 12px;
-}
-
-.commentProfile {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-}
-
-.commentContent {
-  display: flex;
-  flex-direction: column;
-}
-
-.commentUser {
-  font-size: 14px;
-  color: $color-text-1;
-  font-weight: 400;
-}
-
-.commentDate {
-  font-size: 12px;
-  color: $color-text-3;
-}
-
-.commentText {
-  font-size: 14px;
-  color: $color-text-2;
+  font-size: $font-title-sub-size;
+  color: $color-gray;
 }

--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,8 @@
         "noArrayIndexKey": "off"
       },
       "a11y": {
-        "useButtonType": "off"
+        "useButtonType": "off",
+        "useKeyWithClickEvents": "off"
       }
     }
   },

--- a/features/bookmark/container/BookmarkButtonCont.tsx
+++ b/features/bookmark/container/BookmarkButtonCont.tsx
@@ -1,0 +1,18 @@
+'use client';
+// package
+import { useState } from 'react';
+// slice
+import BookmarkButtonPres from '../presentational/BookmarkButtonPres';
+
+export default function BookmarkButtonCont() {
+  const [bookmarked, setBookmarked] = useState(false);
+
+  const toggleBookmark = () => {
+    // 실제 API 호출 자리
+    setBookmarked((prev) => !prev);
+  };
+
+  return (
+    <BookmarkButtonPres bookmarked={bookmarked} onClick={toggleBookmark} />
+  );
+}

--- a/features/bookmark/index.ts
+++ b/features/bookmark/index.ts
@@ -1,0 +1,1 @@
+export { default as BookmarkButton } from './container/BookmarkButtonCont';

--- a/features/bookmark/presentational/BookmarkButtonPres.tsx
+++ b/features/bookmark/presentational/BookmarkButtonPres.tsx
@@ -1,0 +1,22 @@
+// package
+import Image from 'next/image';
+// slice
+import styles from '../styles/BookmarkButton.module.scss';
+
+type Props = {
+  bookmarked: boolean;
+  onClick: () => void;
+};
+
+export default function BookmarkButton({ bookmarked, onClick }: Props) {
+  return (
+    <button className={styles.bookmarkWrapper} onClick={onClick}>
+      <Image
+        src={bookmarked ? '/svgs/book.svg' : '/svgs/book.svg'}
+        alt="bookmark"
+        width={20}
+        height={20}
+      />
+    </button>
+  );
+}

--- a/features/bookmark/styles/BookmarkButton.module.scss
+++ b/features/bookmark/styles/BookmarkButton.module.scss
@@ -1,0 +1,7 @@
+@use "@styles/variables.scss" as *;
+
+.bookmarkWrapper {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}

--- a/features/like/container/LikeButtonCont.tsx
+++ b/features/like/container/LikeButtonCont.tsx
@@ -1,0 +1,21 @@
+'use client';
+// package
+import { useState } from 'react';
+// slice
+import LikeButtonPres from '../presentational/LikeButtonPres';
+
+export default function LikeButtonCont() {
+  const [liked, setLiked] = useState(false);
+  const [count, setCount] = useState(16);
+
+  const toggleLike = () => {
+    if (liked) {
+      setCount((prev) => prev - 1);
+    } else {
+      setCount((prev) => prev + 1);
+    }
+    setLiked((prev) => !prev);
+  };
+
+  return <LikeButtonPres liked={liked} count={count} onClick={toggleLike} />;
+}

--- a/features/like/index.ts
+++ b/features/like/index.ts
@@ -1,0 +1,1 @@
+export { default as LikeButton } from './container/LikeButtonCont';

--- a/features/like/presentational/LikeButtonPres.tsx
+++ b/features/like/presentational/LikeButtonPres.tsx
@@ -1,0 +1,26 @@
+// package
+import Image from 'next/image';
+// slice
+import styles from '../styles/LikeButton.module.scss';
+
+type Props = {
+  liked: boolean;
+  count: number;
+  onClick: () => void;
+};
+
+export default function LikeButton({ liked, count, onClick }: Props) {
+  return (
+    <div className={styles.likeWrapper}>
+      <button className={styles.likeBtn} onClick={onClick}>
+        <Image
+          src={liked ? '/svgs/love.svg' : '/svgs/love.svg'}
+          alt="like"
+          width={20}
+          height={20}
+        />
+      </button>
+      <span className={styles.count}>{count}</span>
+    </div>
+  );
+}

--- a/features/like/styles/LikeButton.module.scss
+++ b/features/like/styles/LikeButton.module.scss
@@ -1,0 +1,16 @@
+@use "@styles/variables.scss" as *;
+
+.likeWrapper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.likeBtn {
+  cursor: pointer;
+}
+
+.count {
+  font-size: $font-sm-size;
+  color: $color-gray;
+}

--- a/shared/ui/profile/Profile.module.scss
+++ b/shared/ui/profile/Profile.module.scss
@@ -1,0 +1,17 @@
+@use "@styles/variables.scss" as *;
+
+.profileInfo {
+  display: flex;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.profileName {
+  font-size: $font-sm-size;
+  color: $color-text-1;
+}
+
+.profileDate {
+  font-size: $font-xs-size;
+  color: $color-text-2;
+}

--- a/shared/ui/profile/index.tsx
+++ b/shared/ui/profile/index.tsx
@@ -4,16 +4,29 @@ import Image from 'next/image';
 import styles from './Profile.module.scss';
 
 type Props = {
+  userProfileImage?: string;
+  userNickName: string;
+  date: string;
   onClick: () => void;
 };
 
-export default function Profile({ onClick }: Props) {
+export default function Profile({
+  userProfileImage,
+  userNickName,
+  date,
+  onClick,
+}: Props) {
   return (
     <div className={styles.profileInfo} onClick={onClick}>
-      <Image src="/svgs/profile.svg" alt="user" width={32} height={32} />
+      <Image
+        src={userProfileImage ?? '/svgs/profile.svg'}
+        alt="user profile image"
+        width={32}
+        height={32}
+      />
       <div>
-        <div className={styles.profileName}>userNickName</div>
-        <div className={styles.profileDate}>2025-01-01</div>
+        <div className={styles.profileName}>{userNickName}</div>
+        <div className={styles.profileDate}>{date}</div>
       </div>
     </div>
   );

--- a/shared/ui/profile/index.tsx
+++ b/shared/ui/profile/index.tsx
@@ -1,0 +1,20 @@
+// package
+import Image from 'next/image';
+// slice
+import styles from './Profile.module.scss';
+
+type Props = {
+  onClick: () => void;
+};
+
+export default function Profile({ onClick }: Props) {
+  return (
+    <div className={styles.profileInfo} onClick={onClick}>
+      <Image src="/svgs/profile.svg" alt="user" width={32} height={32} />
+      <div>
+        <div className={styles.profileName}>userNickName</div>
+        <div className={styles.profileDate}>2025-01-01</div>
+      </div>
+    </div>
+  );
+}

--- a/views/post-detail/container/AiSummaryCont.tsx
+++ b/views/post-detail/container/AiSummaryCont.tsx
@@ -1,0 +1,13 @@
+import AiSummaryPres from '../presentational/AiSummaryPres';
+
+export default function AiSummaryCont() {
+  const summaryList = [
+    { title: '제목1' },
+    { title: '제목2' },
+    { title: '제목3' },
+    { title: '제목4' },
+    { title: '제목5' },
+  ];
+
+  return <AiSummaryPres summaryList={summaryList} />;
+}

--- a/views/post-detail/container/BodyTextCont.tsx
+++ b/views/post-detail/container/BodyTextCont.tsx
@@ -1,0 +1,8 @@
+import BodyTextPres from '../presentational/BodyTextPres';
+
+export default function BodyTextCont() {
+  const dummyBody = `
+CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........CSR은 클라이언트 사이드 렌더링이라고 합니다. 이는 SEO에 좋지 못하지만, 좀더 인터렉티브한 디자인에는 좋은경험을 ........  `;
+
+  return <BodyTextPres body={dummyBody} />;
+}

--- a/views/post-detail/container/CommentInputCont.tsx
+++ b/views/post-detail/container/CommentInputCont.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import CommentInputPres from '../presentational/CommentInputPres';
+
+export default function CommentInputCont() {
+  const [text, setText] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!text.trim()) return;
+
+    try {
+      setIsSubmitting(true);
+      setText('');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <CommentInputPres
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      onSubmit={handleSubmit}
+      isSubmitting={isSubmitting}
+    />
+  );
+}

--- a/views/post-detail/container/CommentInputCont.tsx
+++ b/views/post-detail/container/CommentInputCont.tsx
@@ -7,6 +7,10 @@ export default function CommentInputCont() {
   const [text, setText] = useState<string>('');
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+
   const handleSubmit = async () => {
     if (!text.trim()) return;
 
@@ -23,7 +27,7 @@ export default function CommentInputCont() {
   return (
     <CommentInputPres
       value={text}
-      onChange={(e) => setText(e.target.value)}
+      onChange={onChange}
       onSubmit={handleSubmit}
       isSubmitting={isSubmitting}
     />

--- a/views/post-detail/container/CommentInputCont.tsx
+++ b/views/post-detail/container/CommentInputCont.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import CommentInputPres from '../presentational/CommentInputPres';
 
 export default function CommentInputCont() {
-  const [text, setText] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [text, setText] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const handleSubmit = async () => {
     if (!text.trim()) return;

--- a/views/post-detail/container/CommentListCont.tsx
+++ b/views/post-detail/container/CommentListCont.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import CommentListPres from '../presentational/CommentListPres';
+
+export default function CommentListCont() {
+  const dummyComments = [
+    {
+      userNickName: 'userNickName1',
+      date: '2025-01-01',
+      text: '좋은글 잘읽고 갑니다~',
+    },
+    {
+      userNickName: 'userNickName2',
+      date: '2025-01-02',
+      text: '정말 유익한 정보네요!',
+    },
+    {
+      userNickName: 'userNickName3',
+      date: '2025-01-03',
+      text: '감사합니다! 많은 도움이 되었습니다.',
+    },
+    {
+      userNickName: 'userNickName4',
+      date: '2025-01-04',
+      text: '좋은글 잘읽고 갑니다~',
+    },
+    {
+      userNickName: 'userNickName5',
+      date: '2025-01-05',
+      text: '정말 유익한 정보네요!',
+    },
+  ];
+
+  return <CommentListPres comments={dummyComments} />;
+}

--- a/views/post-detail/index.ts
+++ b/views/post-detail/index.ts
@@ -1,0 +1,1 @@
+export { default as AiSummary } from './container/AiSummaryCont';

--- a/views/post-detail/index.ts
+++ b/views/post-detail/index.ts
@@ -2,3 +2,4 @@ export { default as AiSummary } from './container/AiSummaryCont';
 export { default as BodyText } from './container/BodyTextCont';
 export { default as CommentInput } from './container/CommentInputCont';
 export { default as CommentList } from './container/CommentListCont';
+export { default as CommentLoginPrompt } from './presentational/CommentLoginPromptPres';

--- a/views/post-detail/index.ts
+++ b/views/post-detail/index.ts
@@ -1,3 +1,4 @@
 export { default as AiSummary } from './container/AiSummaryCont';
 export { default as BodyText } from './container/BodyTextCont';
 export { default as CommentInput } from './container/CommentInputCont';
+export { default as CommentList } from './container/CommentListCont';

--- a/views/post-detail/index.ts
+++ b/views/post-detail/index.ts
@@ -1,2 +1,3 @@
 export { default as AiSummary } from './container/AiSummaryCont';
 export { default as BodyText } from './container/BodyTextCont';
+export { default as CommentInput } from './container/CommentInputCont';

--- a/views/post-detail/index.ts
+++ b/views/post-detail/index.ts
@@ -1,1 +1,2 @@
 export { default as AiSummary } from './container/AiSummaryCont';
+export { default as BodyText } from './container/BodyTextCont';

--- a/views/post-detail/presentational/AiSummaryPres.tsx
+++ b/views/post-detail/presentational/AiSummaryPres.tsx
@@ -1,0 +1,25 @@
+import styles from '../styles/AiSummaryPres.module.scss';
+
+type SummaryItem = {
+  title: string;
+};
+
+type Props = {
+  summaryList: SummaryItem[];
+};
+
+export default function AiSummaryPres({ summaryList }: Props) {
+  console.log('summaryList', summaryList);
+  return (
+    <div className={styles.summaryBox}>
+      <div className={styles.summaryTitle}>AI 목차 요약</div>
+      <ol>
+        {summaryList?.map((item, index) => (
+          <li key={index} className={styles.summaryItem}>
+            {item.title}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/views/post-detail/presentational/AiSummaryPres.tsx
+++ b/views/post-detail/presentational/AiSummaryPres.tsx
@@ -9,7 +9,6 @@ type Props = {
 };
 
 export default function AiSummaryPres({ summaryList }: Props) {
-  console.log('summaryList', summaryList);
   return (
     <div className={styles.summaryBox}>
       <div className={styles.summaryTitle}>AI 목차 요약</div>

--- a/views/post-detail/presentational/BodyTextPres.tsx
+++ b/views/post-detail/presentational/BodyTextPres.tsx
@@ -1,0 +1,7 @@
+type Props = {
+  body: string;
+};
+
+export default function BodyTextPres({ body }: Props) {
+  return <div>{body}</div>;
+}

--- a/views/post-detail/presentational/CommentInputPres.tsx
+++ b/views/post-detail/presentational/CommentInputPres.tsx
@@ -1,0 +1,34 @@
+import Button from '@/shared/ui/button';
+import styles from '../styles/CommentInputPres.module.scss';
+
+type Props = {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+};
+
+export default function CommentInputPres({
+  value,
+  onChange,
+  onSubmit,
+  isSubmitting,
+}: Props) {
+  return (
+    <div className={styles.commentBox}>
+      <textarea
+        className={styles.commentInput}
+        placeholder="댓글을 작성해주세요"
+        value={value}
+        onChange={onChange}
+      />
+      <Button
+        size="small"
+        onClick={onSubmit}
+        disabled={isSubmitting || !value.trim()}
+      >
+        댓글 작성
+      </Button>
+    </div>
+  );
+}

--- a/views/post-detail/presentational/CommentListPres.tsx
+++ b/views/post-detail/presentational/CommentListPres.tsx
@@ -1,0 +1,39 @@
+// package
+import Image from 'next/image';
+// slice
+import styles from '../styles/CommentListPres.module.scss';
+
+type Comment = {
+  userNickName: string;
+  date: string;
+  text: string;
+};
+
+type Props = {
+  comments: Comment[];
+};
+
+export default function CommentListPres({ comments }: Props) {
+  return (
+    <div className={styles.commentList}>
+      {comments.map((c, idx) => (
+        <div className={styles.commentItem} key={idx}>
+          <div className={styles.commentUserBox}>
+            <Image
+              src="/svgs/profile.svg"
+              alt="user"
+              width={32}
+              height={32}
+              className={styles.commentProfile}
+            />
+            <div className={styles.commentContent}>
+              <div className={styles.commentUser}>{c.userNickName}</div>
+              <div className={styles.commentDate}>{c.date}</div>
+            </div>
+          </div>
+          <div className={styles.commentText}>{c.text}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/views/post-detail/presentational/CommentListPres.tsx
+++ b/views/post-detail/presentational/CommentListPres.tsx
@@ -1,7 +1,6 @@
-// package
-import Image from 'next/image';
 // slice
 import styles from '../styles/CommentListPres.module.scss';
+import Profile from '@/shared/ui/profile';
 
 type Comment = {
   userNickName: string;
@@ -18,19 +17,11 @@ export default function CommentListPres({ comments }: Props) {
     <div className={styles.commentList}>
       {comments.map((c, idx) => (
         <div className={styles.commentItem} key={idx}>
-          <div className={styles.commentUserBox}>
-            <Image
-              src="/svgs/profile.svg"
-              alt="user"
-              width={32}
-              height={32}
-              className={styles.commentProfile}
-            />
-            <div className={styles.commentContent}>
-              <div className={styles.commentUser}>{c.userNickName}</div>
-              <div className={styles.commentDate}>{c.date}</div>
-            </div>
-          </div>
+          <Profile
+            userNickName={c.userNickName}
+            date={c.date}
+            onClick={() => {}}
+          />
           <div className={styles.commentText}>{c.text}</div>
         </div>
       ))}

--- a/views/post-detail/presentational/CommentLoginPromptPres.tsx
+++ b/views/post-detail/presentational/CommentLoginPromptPres.tsx
@@ -1,0 +1,13 @@
+import styles from '../styles/CommentLoginPromptPres.module.scss';
+import Button from '@/shared/ui/button';
+
+export default function CommentLoginPromptPres() {
+  return (
+    <div className={styles.commentBox}>
+      <div className={styles.commentGuide}>댓글 등록하기</div>
+      <Button variants="active" size="small">
+        로그인
+      </Button>
+    </div>
+  );
+}

--- a/views/post-detail/styles/AiSummaryPres.module.scss
+++ b/views/post-detail/styles/AiSummaryPres.module.scss
@@ -1,0 +1,22 @@
+@use "@styles/variables.scss" as *;
+
+.summaryBox {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: $color-mist-lavender;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.summaryTitle {
+  font-size: $font-title-sub-size;
+  font-weight: 600;
+  color: $color-soft-lavender;
+}
+
+.summaryItem {
+  font-size: $font-sm-size;
+  color: $color-gray;
+}

--- a/views/post-detail/styles/CommentInputPres.module.scss
+++ b/views/post-detail/styles/CommentInputPres.module.scss
@@ -1,0 +1,36 @@
+@use "@styles/variables.scss" as *;
+
+.commentBox {
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: end;
+}
+
+.commentInput {
+  width: 100%;
+  height: 10rem;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid $color-gray-400;
+  font-size: $font-lg-size;
+  margin-bottom: 8px;
+  border: solid 1px $color-gray;
+  resize: none;
+
+  &:focus {
+    outline: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  &::placeholder {
+    color: $color-gray;
+    font-size: $font-base-size;
+  }
+}

--- a/views/post-detail/styles/CommentListPres.module.scss
+++ b/views/post-detail/styles/CommentListPres.module.scss
@@ -1,0 +1,48 @@
+@use "@styles/variables.scss" as *;
+
+.commentList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.commentItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px;
+}
+
+.commentUserBox {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.commentProfile {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+}
+
+.commentContent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.commentUser {
+  font-size: $font-base-size;
+  color: $color-gray;
+}
+
+.commentDate {
+  font-size: $font-sm-size;
+  color: $color-gray;
+}
+
+.commentText {
+  font-size: $font-base-size;
+  color: $color-black;
+}

--- a/views/post-detail/styles/CommentListPres.module.scss
+++ b/views/post-detail/styles/CommentListPres.module.scss
@@ -14,34 +14,6 @@
   padding: 12px;
 }
 
-.commentUserBox {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.commentProfile {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
-}
-
-.commentContent {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.commentUser {
-  font-size: $font-base-size;
-  color: $color-gray;
-}
-
-.commentDate {
-  font-size: $font-sm-size;
-  color: $color-gray;
-}
-
 .commentText {
   font-size: $font-base-size;
   color: $color-black;

--- a/views/post-detail/styles/CommentLoginPromptPres.module.scss
+++ b/views/post-detail/styles/CommentLoginPromptPres.module.scss
@@ -1,0 +1,17 @@
+@use "@styles/variables.scss" as *;
+
+.commentBox {
+  width: 100%;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  background-color: $color-shade-2;
+}
+
+.commentGuide {
+  font-size: $font-base-size;
+  color: $color-gray;
+}


### PR DESCRIPTION
### 작업한 내용
- 북마크 feature 제작
- 좋아요 feature 제작
- biome linter rules에 useKeyWithClickEvents 제거
- 프로필 shared ui 제작
- AI 요약 view 제작
- 본문 view 제작
- 댓글 입력 view 제작
- 비로그인 유저 대상 댓글 작성 로그인 유도 컴포넌트 추가 view 제작
- 댓글 목록 view 제작
-----
### 참고사항
- 게시글 상세보기 page 파일은 게시글과 댓글로 컴포넌트 묶어서 한번 더 분리 예정입니다. 지금은 UI 확인을 위해 임시로 작업해둔 상태입니다.
- 좋아요랑 북마크 버튼 클릭 시 버튼 UI가 변하는 기능은 추후 구현 예정입니다.
- 비로그인 유저 대상 댓글 작성 로그인 유도 컴포넌트는 container에 들어갈 내용이 없다고 판단해 presentation만 제작해 넣어뒀습니다. 이 부분 의견 부탁드립니다.
