### PR TITLE
Feat : 전역 테마 상태관리 생성 및 리팩토링

### DIFF
--- a/app/header/presentational/HeaderPres.tsx
+++ b/app/header/presentational/HeaderPres.tsx
@@ -21,6 +21,7 @@ import PostsSearchCont from '@/features/search-input';
 import Button from '@/shared/ui/button';
 import { useModalStore } from '@/shared/stores/useModalStore';
 import { LoginForm } from '@/widgets/login';
+import { useThemeStore } from '@/shared/stores/useThemeStore';
 
 export default function HeaderPres(): JSX.Element {
   const { open } = useModalStore((state) => state.action);
@@ -31,42 +32,12 @@ export default function HeaderPres(): JSX.Element {
   // 프로필 드롭다운 표시 여부
   const [isProfileDropdownVisible, setIsProfileDropdownVisible] =
     useState(false);
-  // 현재 테마
-  const [currentTheme, setCurrentTheme] = useState('');
+
+  const { theme, toggleTheme } = useThemeStore();
 
   // 드롭다운, 검색창 영역 ref
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchWrapperRef = useRef<HTMLDivElement>(null);
-
-  // 초기 테마를 읽고 변경 사항을 수신하는 Effect
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setCurrentTheme(
-        document.documentElement.getAttribute('data-theme') || '',
-      );
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
-
-    // 초기 테마 설정
-    setCurrentTheme(document.documentElement.getAttribute('data-theme') || '');
-
-    return () => observer.disconnect();
-  }, []);
-
-  // 임시 테마 버튼
-  const changeTheme = () => {
-    const newTheme = currentTheme === 'dark' ? '' : 'dark';
-    if (newTheme === 'dark') {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    } else {
-      document.documentElement.removeAttribute('data-theme');
-    }
-    setCurrentTheme(newTheme); // 상태를 업데이트합니다.
-  };
 
   // 검색창 영역 밖 클릭 시 검색창 닫기
   useOnClickOutside(
@@ -112,9 +83,7 @@ export default function HeaderPres(): JSX.Element {
       {/* 로고 */}
       <Link href="/" className={styles.logo}>
         <Image
-          src={
-            currentTheme === 'dark' ? '/svgs/logo_dark.svg' : '/svgs/logo.svg'
-          }
+          src={theme === 'dark' ? '/svgs/logo_dark.svg' : '/svgs/logo.svg'}
           alt="로고"
           fill
           style={{ objectFit: 'contain' }}
@@ -142,7 +111,7 @@ export default function HeaderPres(): JSX.Element {
         )}
       </div>
 
-      <button onClick={changeTheme}>테마전환</button>
+      <button onClick={toggleTheme}>테마전환</button>
 
       {/* 네비게이션 */}
       <nav

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import styles from './styles/layout.module.scss';
 
 import Header from '@/app/header';
 import Modal from '@/shared/ui/modal';
+import ApplyTheme from '@/shared/ApplyTheme';
 
 const pretendard = localFont({
   src: '../public/fonts/pretendard-medium.woff2',
@@ -27,13 +28,14 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.className}`}>
       <body>
+        <ApplyTheme />
         <div className={styles.layout}>
           <div className={styles.layout__header}>
             <Header />
           </div>
           <main className={styles.layout__main}>{children}</main>
         </div>
-        <Modal/>
+        <Modal />
       </body>
     </html>
   );

--- a/shared/ApplyTheme.tsx
+++ b/shared/ApplyTheme.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useLayoutEffect } from 'react';
+
+import { useThemeStore } from '@/shared/stores/useThemeStore';
+
+export default function ApplyTheme() {
+  const theme = useThemeStore((state) => state.theme);
+
+  useLayoutEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+  }, [theme]);
+
+  return null;
+}

--- a/shared/stores/useThemeStore.tsx
+++ b/shared/stores/useThemeStore.tsx
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type Theme = '' | 'dark';
+
+type ThemeState = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: '',
+      toggleTheme: () =>
+        set((state) => ({ theme: state.theme === '' ? 'dark' : '' })),
+    }),
+    {
+      name: 'theme-storage', // localStorage 키
+    },
+  ),
+);


### PR DESCRIPTION
### 작업한 내용
- zustand를 이용해 전역 테마 상태관리 store(useThemeStore) 생성
- ApplyTheme 컴포넌트 제작하여 theme 상태에 따라 data-theme 속성 제어
- RootLayout에 ApplyTheme 적용해 전역 테마 반영
- 기존 HeaderPres 컴포넌트 내 테마 관련 로직을 useThemeStore 기반으로 리팩토링
-----
### 참고사항
- ApplyTheme 컴포넌트 위치가 명확하지 않아 일단 shared 폴더 내에 생성하였음

