### PR TITLE
Refactor : 이미지 업로드 로직 클린 아키텍처로 분리 및 API 경로 변경

### DIFF
--- a/app/api/member/posts/upload/route.ts
+++ b/app/api/member/posts/upload/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+
+import { UploadImgUsecase } from '@/back/upload/application/usecases/UploadImgUsecase';
+import { PrUploadImgS3Repository } from '@/back/upload/infra/UploadImgToS3Repository';
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+
+    const files = formData.getAll('img') as File[];
+
+    if (files.length === 0) {
+      return new Response(
+        JSON.stringify({ message: '이미지 파일이 없습니다.' }),
+        { status: 400 },
+      );
+    }
+
+    const repository = new PrUploadImgS3Repository();
+    const uploadImg = new UploadImgUsecase(repository);
+    const urls = await uploadImg.execute(files);
+
+    return new Response(
+      JSON.stringify({
+        message: '업로드 성공',
+        data: urls.length === 1 ? urls[0] : urls,
+      }),
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('이미지 업로드 실패:', error);
+    return new Response(
+      JSON.stringify({ message: '이미지 업로드 중 오류 발생' }),
+      { status: 500 },
+    );
+  }
+}

--- a/back/upload/application/usecases/UploadImgUsecase.ts
+++ b/back/upload/application/usecases/UploadImgUsecase.ts
@@ -1,0 +1,11 @@
+import { UploadImgRepository } from '../../domain/UploadImgRepository';
+
+export class UploadImgUsecase {
+  constructor(private readonly uploadImgRepository: UploadImgRepository) {}
+
+  async execute(files: File[]): Promise<string[]> {
+    const url = await this.uploadImgRepository.uploadImg(files);
+
+    return url;
+  }
+}

--- a/back/upload/domain/UploadImgRepository.ts
+++ b/back/upload/domain/UploadImgRepository.ts
@@ -1,0 +1,3 @@
+export interface UploadImgRepository {
+  uploadImg(files: File[]): Promise<string[]>;
+}

--- a/back/upload/infra/UploadImgToS3Repository.ts
+++ b/back/upload/infra/UploadImgToS3Repository.ts
@@ -1,5 +1,6 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { NextRequest } from 'next/server';
+
+import { UploadImgRepository } from '../domain/UploadImgRepository';
 
 const Bucket = process.env.AWS_BUCKET_NAME;
 
@@ -11,15 +12,12 @@ const s3 = new S3Client({
   },
 });
 
-export async function POST(req: NextRequest) {
-  try {
-    const formData = await req.formData();
-    const files = formData.getAll('img') as File[];
-
+export class PrUploadImgS3Repository implements UploadImgRepository {
+  async uploadImg(files: File[]): Promise<string[]> {
     const uploadPromises = files.map(async (file) => {
       const Body = Buffer.from(await file.arrayBuffer());
       const extension = file.name.split('.').pop();
-      const randomStr = Math.random().toString(36).substring(2, 8); // 랜덤 문자열
+      const randomStr = Math.random().toString(36).substring(2, 8);
       const timestamp = Date.now();
       const fileName = `${timestamp}_${randomStr}.${extension}`;
       const ContentType = file.type || 'image/jpeg';
@@ -37,20 +35,23 @@ export async function POST(req: NextRequest) {
       return imageUrl;
     });
 
-    const imgUrls = await Promise.all(uploadPromises);
+    const results = await Promise.allSettled(uploadPromises);
 
-    return new Response(
-      JSON.stringify({
-        data: imgUrls.length === 1 ? imgUrls[0] : imgUrls,
-        message: 'OK',
-      }),
-      { status: 200 },
-    );
-  } catch (error) {
-    console.error('Error uploading files:', error);
-    return new Response(
-      JSON.stringify({ message: '파일 업로드 중 오류가 발생했습니다.' }),
-      { status: 500 },
-    );
+    // 성공한 것만 추출
+    const successfulUrls = results
+      .filter(
+        (result): result is PromiseFulfilledResult<string> =>
+          result.status === 'fulfilled',
+      )
+      .map((result) => result.value);
+
+    // 실패한 로그 출력 (선택)
+    results
+      .filter((result) => result.status === 'rejected')
+      .forEach((result, idx) => {
+        console.error(`업로드 실패 (index ${idx}):`, result.reason);
+      });
+
+    return successfulUrls;
   }
 }

--- a/views/post/post-draft/container/PostDraftListCont.tsx
+++ b/views/post/post-draft/container/PostDraftListCont.tsx
@@ -1,11 +1,7 @@
 import { usePostEditorStore } from '../../stores/usePostEditorStore';
 import PostDraftListPres from '../presentational/PostDraftListPres';
 
-type Props = {
-  closeModal: () => void;
-};
-
-export default function PostDraftListCont({ closeModal }: Props) {
+export default function PostDraftListCont() {
   const { deleteDraft: onDelete } = usePostEditorStore();
 
   /** 임시 저장 글 삭제 로직 */
@@ -22,5 +18,5 @@ export default function PostDraftListCont({ closeModal }: Props) {
     }
   };
 
-  return <PostDraftListPres onDelete={deleteDraft} closeModal={closeModal} />;
+  return <PostDraftListPres onDelete={deleteDraft} />;
 }

--- a/views/post/post-draft/presentational/PostDraftListPres.tsx
+++ b/views/post/post-draft/presentational/PostDraftListPres.tsx
@@ -4,18 +4,19 @@ import styles from '../styles/PostDraftListPres.module.scss';
 
 import { BlogPostDraftType } from '../types';
 import { usePostEditorStore } from '../../stores/usePostEditorStore';
+import { useModalStore } from '@/shared/stores/useModalStore';
 
 type Props = {
   onDelete: (id: number) => void;
-  closeModal: () => void;
 };
 
-export default function PostDraftListPres({ onDelete, closeModal }: Props) {
+export default function PostDraftListPres({ onDelete }: Props) {
   const { drafts, setSelectedPost } = usePostEditorStore();
+  const { action } = useModalStore();
 
   const handleSelectDraft = (data: BlogPostDraftType) => {
     setSelectedPost(data);
-    closeModal();
+    action.close();
   };
 
   return (

--- a/views/post/post-form/container/PostFormCont.tsx
+++ b/views/post/post-form/container/PostFormCont.tsx
@@ -121,7 +121,7 @@ export default function PostFormCont() {
       formData.append('img', file); // 서버에서 받는 필드명 'img'
     });
 
-    const res = await fetch('/api/member/posts/s3-upload', {
+    const res = await fetch('/api/member/posts/upload', {
       method: 'POST',
       body: formData,
     });

--- a/views/post/post-form/presentational/PostFormPres.tsx
+++ b/views/post/post-form/presentational/PostFormPres.tsx
@@ -133,9 +133,7 @@ export default function PostFormPres(props: Props) {
             </button>
             <button
               className={`${styles.toggleButton} ${styles.countButton}`}
-              onClick={() =>
-                action.open(<PostDraftListCont closeModal={closeModal} />)
-              }
+              onClick={() => action.open(<PostDraftListCont />)}
             >
               {drafts?.length}
             </button>

--- a/views/post/post-form/presentational/PostFormPres.tsx
+++ b/views/post/post-form/presentational/PostFormPres.tsx
@@ -62,10 +62,6 @@ export default function PostFormPres(props: Props) {
     setIsPublic((prev) => (prev === 0 ? 1 : 0));
   };
 
-  const closeModal = () => {
-    action.close();
-  };
-
   /* 이미지 드래그 앤 드랍 관련 커스텀 훅 */
   useImageDrop({
     ref: editorRef,


### PR DESCRIPTION
### 작업한 내용
- 기존 /api/member/posts/s3-upload에 작성되어 있던 이미지 업로드 로직을 클린 아키텍처 방식으로 분리하였습니다.
- 이미지 업로드 경로를 /api/member/posts/upload로 변경하였습니다.


-----
### 참고사항

- 이미지를 업로드할 때 img 라는 필드명으로 FormData에 추가해야 합니다.

예시 코드

```
const uploadImg = async() => {
    const formData = new FormData();

  files.forEach((file) => {
    formData.append('img', file); // 서버에서 받는 필드명은 'img'
  });

  const res = await fetch('/api/member/posts/upload', {
    method: 'POST',
    body: formData,
  });


```
