### PR TITLE
Fix :  댓글 삭제 API에서 params를 Promise 형태로 처리하도록 수정

### DIFF
--- a/app/api/member/comments/[id]/route.ts
+++ b/app/api/member/comments/[id]/route.ts
@@ -43,16 +43,18 @@ export async function PATCH(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    const { id } = await params;
+
     const userData = await getToken({ req, secret: process.env.AUTH_SECRET });
     if (!userData || !userData.sub) {
       return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
 
     const usecase = new DeleteCommentUsecase(new PrCommentRepository());
-    await usecase.execute(Number(params.id), userData.sub);
+    await usecase.execute(Number(id), userData.sub);
 
     return NextResponse.json(
       { message: '댓글이 삭제되었습니다.' },


### PR DESCRIPTION
### 작업한 내용
-  댓글 삭제 API에서 params를 Promise 형태로 처리하도록 수정했습니다. 
-----
### 참고사항
- 
