### PR TITLE
Refactor: 팔로워|팔로잉 모달 탭 전환 방식을 토글에서 버튼 클릭으로 변경

### DIFF
--- a/features/subscription-list/container/SubscriptionListCont.tsx
+++ b/features/subscription-list/container/SubscriptionListCont.tsx
@@ -16,8 +16,8 @@ export default function SubscriptionListCont({
 }: SubscribeProps) {
   const [followState, setFollowState] = useState(isFollow);
 
-  const handleFollowListDisplay = () => {
-    setFollowState((prev) => !prev);
+  const handleFollowListDisplay = (value: boolean) => {
+    setFollowState(value);
   };
   return (
     <>

--- a/features/subscription-list/presentational/SubscriptionListPres.tsx
+++ b/features/subscription-list/presentational/SubscriptionListPres.tsx
@@ -4,7 +4,7 @@ import PostsSearchCont from '@/features/search-input';
 import styles from '../styles/subscriptionList.module.scss';
 import { SubscribeUser } from '@/views/story/profile-card/types';
 type UserListProps = {
-  handleFollowListDisplay: () => void;
+  handleFollowListDisplay: (value: boolean) => void;
   isFollow: boolean;
   followerList: SubscribeUser;
   followList: SubscribeUser;
@@ -29,6 +29,7 @@ export default function SubscriptionListPres({
                         ? styles.toggleTextActive
                         : styles.toggleTextBasic
                     }
+                    onClick={() => handleFollowListDisplay(true)} // 팔로워 클릭
                   >
                     팔로워
                   </span>
@@ -39,17 +40,18 @@ export default function SubscriptionListPres({
                         ? styles.toggleTextBasic
                         : styles.toggleTextActive
                     }
+                    onClick={() => handleFollowListDisplay(false)} // 팔로잉 클릭
                   >
                     팔로잉
                   </span>
                 </div>
               </div>
-              <div
+              {/* <div
                 onClick={handleFollowListDisplay}
                 className={`${styles.toggle} ${isFollow ? '' : styles.movieToggle}`}
               >
                 <span className={styles.toggleCurrent}></span>
-              </div>
+              </div> */}
             </div>
             <div className={styles.searchbar}>
               <PostsSearchCont />
@@ -57,7 +59,24 @@ export default function SubscriptionListPres({
           </div>
         </div>
         <div className={styles.list}>
-          {isFollow
+          {(isFollow ? followerList?.users : followList?.users)?.map(
+            (item, index) => (
+              <div className={styles.flexCenter} key={index}>
+                <div className={styles.userListContainer}>
+                  <div className={styles.imgBox}>
+                    <Image
+                      src={item.profileImg ?? '/svgs/profile.svg'}
+                      alt="프로필이미지"
+                      width={40}
+                      height={40}
+                    />
+                  </div>
+                  <div className={styles.userName}>{item.name}</div>
+                </div>
+              </div>
+            ),
+          )}
+          {/* {isFollow
             ? followerList?.users?.map((item, index) => {
                 return (
                   <div className={styles.flexCenter} key={index}>
@@ -97,7 +116,7 @@ export default function SubscriptionListPres({
                     </div>
                   </div>
                 );
-              })}
+              })} */}
         </div>
       </div>
     </>

--- a/features/subscription-list/presentational/SubscriptionListPres.tsx
+++ b/features/subscription-list/presentational/SubscriptionListPres.tsx
@@ -21,22 +21,28 @@ export default function SubscriptionListPres({
         <div className={styles.flex}>
           <div className={styles.flexColumn}>
             <div className={styles.subscriptionBox}>
-              <div className={styles.followGap}>
-                <span
-                  className={
-                    isFollow ? styles.toggleTextActive : styles.toggleTextBasic
-                  }
-                >
-                  팔로워
-                </span>
-                <span className={styles.text}>/</span>
-                <span
-                  className={
-                    isFollow ? styles.toggleTextBasic : styles.toggleTextActive
-                  }
-                >
-                  팔로잉
-                </span>
+              <div className={styles.followGapWrapper}>
+                <div className={styles.followGap}>
+                  <span
+                    className={
+                      isFollow
+                        ? styles.toggleTextActive
+                        : styles.toggleTextBasic
+                    }
+                  >
+                    팔로워
+                  </span>
+                  <span className={styles.text}>|</span>
+                  <span
+                    className={
+                      isFollow
+                        ? styles.toggleTextBasic
+                        : styles.toggleTextActive
+                    }
+                  >
+                    팔로잉
+                  </span>
+                </div>
               </div>
               <div
                 onClick={handleFollowListDisplay}

--- a/features/subscription-list/styles/subscriptionList.module.scss
+++ b/features/subscription-list/styles/subscriptionList.module.scss
@@ -1,18 +1,44 @@
 @use '@styles/variables.scss' as *;
 @use '@styles/mixins.scss' as *;
-.container{
+
+.container {
   height: 500px;
   margin-top: 2rem;
   box-shadow: 3px 3px 10px 1px rgba(0, 0, 0, 0.25);
   border-radius: 8px;
   padding: 20px;
   position: relative;
-  background-color:$theme-shade-2;
+  background-color: $theme-shade-2;
 }
-.searchbar{
+
+.searchbar {
   max-width: 300px;
 }
+
+.subscriptionBox {
+  position: relative;
+  margin-bottom: 20px;
+  height: 40px;
+  white-space: nowrap; 
+}
+
+.followGap {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap; 
+}
+
 .toggle {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   width: 35px;
   height: 17px;
   border: 2px solid $theme-primary;
@@ -20,9 +46,9 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  position: relative;
   padding: 1px;
   background-color: $theme-shade-4;
+  flex-shrink: 0;
 
   .toggleCurrent {
     position: absolute;
@@ -36,74 +62,67 @@
     transform: translateX(0);
   }
 
-  &.movieToggle {
-    .toggleCurrent {
-      transform: translateX(18px); 
-    }
+  &.movieToggle .toggleCurrent {
+    transform: translateX(18px);
   }
 }
 
-  .flex {
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-  }
-  .flexColumn{
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-  }
-  .followGap{
-    display: flex;
-    gap: 12px;
-  }
-  .subscriptionBox{
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 20px;
-  }
-  .toggleTextActive{
-    @include font-xl;
-    color:$theme-primary;
-    font-weight: 200
-  }
-  .toggleTextBasic{
-    @include font-xl;
-    color: $theme-text-2;
-    font-weight: 200
-  }
-  .list{
-    display: flex;
-    flex-direction: column;
-    
-  }
-  .flexCenter{
-    display: flex;
-    justify-items: center;
-    margin-top: 5px;
-  }
-  .text{
-    font-size:20px ;
-    color: $theme-text-1;
-  }
-  .userListContainer{
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: space-around;
-    margin-top: 25px;
-    gap: 65px;
-  }
- 
-  .userName{
-    color: $theme-text-2;
-    @include font-xl;
-    text-align: center;
-  }
-  .imgBox{
-    border-radius: 100%;
-    text-align: center;
-  }
-  
+.flex {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.flexColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.toggleTextActive {
+  @include font-xl;
+  color: $theme-primary;
+  font-weight: 200;
+}
+
+.toggleTextBasic {
+  @include font-xl;
+  color: $theme-text-2;
+  font-weight: 200;
+}
+
+.text {
+  font-size: 20px;
+  color: $theme-text-1;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.flexCenter {
+  display: flex;
+  justify-items: center;
+  margin-top: 5px;
+}
+
+.userListContainer {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-around;
+  margin-top: 25px;
+  gap: 65px;
+}
+
+.userName {
+  color: $theme-text-2;
+  @include font-xl;
+  text-align: center;
+}
+
+.imgBox {
+  border-radius: 100%;
+  text-align: center;
+}

--- a/features/subscription-list/styles/subscriptionList.module.scss
+++ b/features/subscription-list/styles/subscriptionList.module.scss
@@ -1,8 +1,7 @@
 @use '@styles/variables.scss' as *;
 @use '@styles/mixins.scss' as *;
 .container{
-  width: 550px;
-  height: 700px;
+  height: 500px;
   margin-top: 2rem;
   box-shadow: 3px 3px 10px 1px rgba(0, 0, 0, 0.25);
   border-radius: 8px;
@@ -11,7 +10,7 @@
   background-color:$theme-shade-2;
 }
 .searchbar{
-  width: 300px;
+  max-width: 300px;
 }
 .toggle {
   width: 35px;
@@ -44,7 +43,7 @@
   }
 }
 
-.flex {
+  .flex {
     display: flex;
     align-items: center;
     justify-content: space-around;
@@ -56,18 +55,18 @@
   }
   .followGap{
     display: flex;
-    gap: 25px;
+    gap: 12px;
   }
   .subscriptionBox{
     display: flex;
-    gap: 10px;
+    gap: 12px;
     align-items: center;
-    justify-content: space-around;
+    justify-content: center;
     margin-bottom: 20px;
   }
   .toggleTextActive{
     @include font-xl;
-    color:#5B53E8;
+    color:$theme-primary;
     font-weight: 200
   }
   .toggleTextBasic{
@@ -78,7 +77,6 @@
   .list{
     display: flex;
     flex-direction: column;
-    padding-left: 150px;
     
   }
   .flexCenter{
@@ -92,8 +90,9 @@
   }
   .userListContainer{
     display: flex;
+    width: 100%;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-around;
     margin-top: 25px;
     gap: 65px;
   }

--- a/features/subscription-list/styles/subscriptionList.module.scss
+++ b/features/subscription-list/styles/subscriptionList.module.scss
@@ -9,86 +9,56 @@
   padding: 20px;
   position: relative;
   background-color: $theme-shade-2;
-}
-
-.searchbar {
-  max-width: 300px;
-}
-
-.subscriptionBox {
-  position: relative;
-  margin-bottom: 20px;
-  height: 40px;
-  white-space: nowrap; 
-}
-
-.followGap {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
   display: flex;
-  gap: 12px;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap; 
-}
-
-.toggle {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 35px;
-  height: 17px;
-  border: 2px solid $theme-primary;
-  border-radius: 30px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  padding: 1px;
-  background-color: $theme-shade-4;
-  flex-shrink: 0;
-
-  .toggleCurrent {
-    position: absolute;
-    left: 0px;
-    top: -0.3px;
-    background-color: $theme-primary;
-    border-radius: 100%;
-    width: 14px;
-    height: 14px;
-    transition: transform 0.3s ease;
-    transform: translateX(0);
-  }
-
-  &.movieToggle .toggleCurrent {
-    transform: translateX(18px);
-  }
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .flex {
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
 }
 
 .flexColumn {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 10px;
+  width: 100%;
+}
+
+.subscriptionBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  width: 100%;
+}
+
+.followGapWrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.followGap {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  white-space: nowrap;
+  cursor: pointer;
 }
 
 .toggleTextActive {
   @include font-xl;
   color: $theme-primary;
-  font-weight: 200;
+  font-weight: bold;
 }
 
 .toggleTextBasic {
   @include font-xl;
   color: $theme-text-2;
-  font-weight: 200;
+  font-weight: 400;
 }
 
 .text {
@@ -96,33 +66,40 @@
   color: $theme-text-1;
 }
 
+.searchbar {
+  max-width: 300px;
+  margin: 0 auto;
+}
+
 .list {
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  max-height: 300px;
+  padding: 0 8px;
 }
 
 .flexCenter {
   display: flex;
-  justify-items: center;
-  margin-top: 5px;
+  justify-content: center;
 }
 
 .userListContainer {
   display: flex;
-  width: 100%;
   align-items: center;
-  justify-content: space-around;
-  margin-top: 25px;
-  gap: 65px;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 300px;
+}
+
+.imgBox {
+  border-radius: 100%;
+  overflow: hidden;
 }
 
 .userName {
   color: $theme-text-2;
   @include font-xl;
-  text-align: center;
-}
-
-.imgBox {
-  border-radius: 100%;
-  text-align: center;
+  word-break: break-word;
 }

--- a/features/subscription-list/styles/subscriptionList.module.scss
+++ b/features/subscription-list/styles/subscriptionList.module.scss
@@ -94,10 +94,17 @@
 }
 
 .imgBox {
-  border-radius: 100%;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
   overflow: hidden;
-}
 
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
 .userName {
   color: $theme-text-2;
   @include font-xl;


### PR DESCRIPTION
### 작업한 내용
- 팔로우/팔로잉 모달 크기 조정
- 토글 버전 모달에서 헤더 텍스트 가운데 정렬
- 팔로우/팔로잉 모달 탭 전환 방식을 토글에서 버튼 클릭으로 변경
- 팔로우/팔로잉 리스트 모달에서 유저 프로필 사진이 세로로 늘어나는 문제 수정
-----
### 참고사항
- 
